### PR TITLE
init and uninstall scripts

### DIFF
--- a/cf-waydroid-init.sh
+++ b/cf-waydroid-init.sh
@@ -10,10 +10,10 @@ fi
 python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 
 # Capture Environment variables excluding LS_COLORS and PYTHONPATH
-env | grep -v '^LS_COLORS=' | grep -v '^PYTHONPATH=' > /etc/waydroid/environment
+env | grep -v '^LS_COLORS=' | grep -v '^PYTHONPATH=' > /tmp/waydroid
 
 # Append PYTHONPATH to environment file
-echo "PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python${python_version}/site-packages" >> /etc/waydroid/environment
+echo "PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python${python_version}/site-packages" >> /tmp/waydroid
 
 # Enable and start waydroid-container.service
 systemctl enable waydroid-container.service
@@ -28,9 +28,15 @@ initialize_waydroid() {
     esac
 }
 
+# Trap to cleanup .env on EXIT
+cleanup() {
+    rm -f /tmp/waydroid
+}
+trap cleanup EXIT
+
 # Load Waydroid environment variables
 set -o allexport
-source /etc/waydroid/environment
+source /tmp/waydroid
 set +o allexport
 
 # Main script
@@ -47,3 +53,5 @@ case $choice in
     1|2) initialize_waydroid $choice ;;
     *) echo "Exiting." ;;
 esac
+
+exit 0

--- a/cf-waydroid-init.sh
+++ b/cf-waydroid-init.sh
@@ -14,6 +14,7 @@ env | grep -v '^LS_COLORS=' | grep -v '^PYTHONPATH=' > /tmp/waydroid
 
 # Append PYTHONPATH to environment file
 echo "PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python${python_version}/site-packages" >> /tmp/waydroid
+chmod -w /tmp/waydroid
 
 # Enable and start waydroid-container.service
 systemctl enable waydroid-container.service
@@ -30,6 +31,7 @@ initialize_waydroid() {
 
 # Trap to cleanup .env on EXIT
 cleanup() {
+    chmod +w /tmp/waydroid
     rm -f /tmp/waydroid
 }
 trap cleanup EXIT

--- a/cf-waydroid-init.sh
+++ b/cf-waydroid-init.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Check if running as root (sudo)
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run with sudo or as root."
+    exit 1
+fi
+
+# Determine Python version dynamically
+python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+
+# Capture Environment variables excluding LS_COLORS and PYTHONPATH
+env | grep -v '^LS_COLORS=' | grep -v '^PYTHONPATH=' > /etc/waydroid/environment
+
+# Append PYTHONPATH to environment file
+echo "PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python${python_version}/site-packages" >> /etc/waydroid/environment
+
+# Enable and start waydroid-container.service
+systemctl enable waydroid-container.service
+systemctl start waydroid-container.service
+
+# Function to initialize Waydroid based on user selection
+initialize_waydroid() {
+    case $1 in
+        1) waydroid init ;;
+        2) waydroid init -s GAPPS ;;
+        *) return 1 ;;
+    esac
+}
+
+# Load Waydroid environment variables
+set -o allexport
+source /etc/waydroid/environment
+set +o allexport
+
+# Main script
+echo "Select an option:"
+echo "1. Initialize Waydroid"
+echo "2. Initialize Waydroid with GAPPS"
+echo "3. Exit"
+
+# Prompt user for choice
+read -p "Enter your choice (1, 2, or 3): " choice
+
+# Validate user input and call function
+case $choice in
+    1|2) initialize_waydroid $choice ;;
+    *) echo "Exiting." ;;
+esac

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -11,7 +11,7 @@ sudo swupd bundle-add kvm-host containers-basic
 
 # Directory for kernel configuration
 cmdline_dir="/etc/kernel/cmdline.d"
-sudo mkdir -p "$cmdline_dir"
+[ ! -d "$cmdline_dir" ] && sudo mkdir -p "$cmdline_dir"
 
 # Array for kernel params, change if needed.
 kernel_params=(

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -19,7 +19,7 @@ kernel_params=(
     "psi=1"
 )
 
-# Function to check if a line already exists
+# Function to check if line already exists
 line_checker() {
     for conf in "$cmdline_dir"/*.conf; do
         if [[ -f "$conf" ]] && grep -qFx "$1" "$conf"; then

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -68,6 +68,7 @@ source_dir="/opt/3rd-party/bundles/clearfraction/usr"
 target_dir="/usr"
 for file in "${files[@]}"; do
     if [ -e "$source_dir$file" ]; then
+        echo "Creating symlink "$target_dir$file" --> "$source_dir$file""
         ln -sf "$source_dir$file" "$target_dir$file"
     else
         echo "File $source_dir$file does not exist."

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -19,7 +19,7 @@ kernel_params=(
     "psi=1"
 )
 
-# Function to check if line already exists
+# Function to check if a line already exists
 line_checker() {
     for conf in "$cmdline_dir"/*.conf; do
         if [[ -f "$conf" ]] && grep -qFx "$1" "$conf"; then
@@ -41,5 +41,37 @@ sudo clr-boot-manager update
 
 # Enable libvirtd and additional services
 sudo systemctl enable libvirtd libvirt-guests virtlxcd virtstoraged virtnetworkd virtnodedevd
+
+# Array for creating symlinks, change if needed
+files=(
+    "/lib/systemd/system/lxc-monitord.service"
+    "/lib/systemd/system/lxc-net.service"
+    "/lib/systemd/system/lxc.service"
+    "/lib/systemd/system/lxc@.service"
+    "/lib/systemd/system/waydroid-container.service"
+    "/lib/tmpfiles.d/lxc.conf"
+    "/libexec/lxc/hooks/unmount-namespace"
+    "/libexec/lxc/lxc-apparmor-load"
+    "/libexec/lxc/lxc-containers"
+    "/libexec/lxc/lxc-monitord"
+    "/libexec/lxc/lxc-net"
+    "/libexec/lxc/lxc-user-nic"
+    "/sbin/init.lxc"
+    "/share/dbus-1/system-services/id.waydro.Container.service"
+    "/share/dbus-1/system.d/id.waydro.Container.conf"
+    "/share/polkit-1/actions"
+    "/share/lxc"
+)
+
+# Iterate over array
+source_dir="/opt/3rd-party/bundles/clearfraction/usr"
+target_dir="/usr"
+for file in "${files[@]}"; do
+    if [ -e "$source_dir$file" ]; then
+        ln -sfn "$source_dir$file" "$target_dir$file"
+    else
+        echo "File $source_dir$file does not exist."
+    fi
+done
 
 echo "Setup complete. Restart for the bootloader configuration to take effect"

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -68,7 +68,7 @@ source_dir="/opt/3rd-party/bundles/clearfraction/usr"
 target_dir="/usr"
 for file in "${files[@]}"; do
     if [ -e "$source_dir$file" ]; then
-        ln -sfn "$source_dir$file" "$target_dir$file"
+        ln -sf "$source_dir$file" "$target_dir$file"
     else
         echo "File $source_dir$file does not exist."
     fi

--- a/cf-waydroid-uninstall
+++ b/cf-waydroid-uninstall
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Check if running as root (sudo)
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run with sudo or as root."
+    exit 1
+fi
+
+# Stop and disable waydroid-container.service
+systemctl stop waydroid-container.service
+systemctl disable waydroid-container.service
+
+# Remove local directories
+sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid
+
+# Array of symlinks
+files=(
+    "/lib/systemd/system/lxc-monitord.service"
+    "/lib/systemd/system/lxc-net.service"
+    "/lib/systemd/system/lxc.service"
+    "/lib/systemd/system/lxc@.service"
+    "/lib/systemd/system/waydroid-container.service"
+    "/lib/tmpfiles.d/lxc.conf"
+    "/libexec/lxc/hooks/unmount-namespace"
+    "/libexec/lxc/lxc-apparmor-load"
+    "/libexec/lxc/lxc-containers"
+    "/libexec/lxc/lxc-monitord"
+    "/libexec/lxc/lxc-net"
+    "/libexec/lxc/lxc-user-nic"
+    "/sbin/init.lxc"
+    "/share/dbus-1/system-services/id.waydro.Container.service"
+    "/share/dbus-1/system.d/id.waydro.Container.conf"
+    "/share/polkit-1/actions"
+    "/share/lxc"
+)
+
+# Remove symlinks
+for file in "${files[@]}"; do
+    sudo rm -f "/usr$file"
+done
+
+# Remove Waydroid environment file
+sudo rm -f /etc/waydroid/environment
+
+echo "Waydroid uninstallation complete."

--- a/cf-waydroid-uninstall
+++ b/cf-waydroid-uninstall
@@ -39,9 +39,6 @@ for file in "${files[@]}"; do
     sudo rm -f "/usr$file"
 done
 
-# Remove Waydroid environment file
-sudo rm -f /etc/waydroid/environment
-
 # Remove kernel config file
 sudo rm -f /etc/kernel/cmdline.d/lxc.conf
 

--- a/cf-waydroid-uninstall
+++ b/cf-waydroid-uninstall
@@ -42,4 +42,13 @@ done
 # Remove Waydroid environment file
 sudo rm -f /etc/waydroid/environment
 
-echo "Waydroid uninstallation complete."
+# Remove kernel config file
+sudo rm -f /etc/kernel/cmdline.d/lxc.conf
+
+# Update boot manager
+sudo clr-boot-manager update
+
+# Remove bundles
+sudo swupd bundle-remove kvm-host containers-basic
+
+echo "Waydroid uninstallation complete. Add the bundles again if needed"


### PR DESCRIPTION
PR uses current working method,
Other ideas needed for environment file?
EDIT:  ̶i̶n̶i̶t̶ ̶s̶c̶r̶i̶p̶t̶ ̶s̶e̶e̶m̶s̶ ̶t̶o̶ ̶n̶o̶t̶ ̶b̶e̶ ̶c̶r̶e̶a̶t̶i̶n̶g̶ ̶t̶h̶e̶ ̶e̶n̶v̶i̶r̶o̶n̶m̶e̶n̶t̶ ̶f̶i̶l̶e̶ ̶c̶o̶r̶r̶e̶c̶t̶l̶y̶  false alarm
EDIT2: systemd service no longer needs the Environmentfile but the waydroid init command still needs it so I leave it here. (can probably add a delete file after the script is done)
EDIT3: Added a trap upon script exit