### PR TITLE
Export PYTHONPATH globally

### DIFF
--- a/cf-waydroid-init.sh
+++ b/cf-waydroid-init.sh
@@ -16,12 +16,6 @@ env | grep -v '^LS_COLORS=' | grep -v '^PYTHONPATH=' > /tmp/waydroid
 echo "PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python${python_version}/site-packages" >> /tmp/waydroid
 chmod -w /tmp/waydroid
 
-# export PYTHONPATH globally to fix Waydroid issue
-
-sudo tee -a /etc/environment.d/11-cf-waydroid.conf << EOF
-PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python3.12/site-packages/
-EOF
-
 # Trap to cleanup .env on EXIT
 cleanup() {
     chmod +w /tmp/waydroid

--- a/cf-waydroid-init.sh
+++ b/cf-waydroid-init.sh
@@ -18,15 +18,14 @@ chmod -w /tmp/waydroid
 
 # export PYTHONPATH globally to fix Waydroid issue
 
-export ORIGIN_PYTHONPATH=${PYTHONPATH}
-export PYTHONPATH=$(echo /opt/3rd-party/bundles/clearfraction/usr/lib/python*/)site-packages/:${PYTHONPATH}
+sudo tee -a /etc/environment.d/11-cf-waydroid.conf << EOF
+PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python3.12/site-packages/
+EOF
 
 # Trap to cleanup .env on EXIT
 cleanup() {
     chmod +w /tmp/waydroid
     rm -f /tmp/waydroid
-    export PYTHONPATH=${ORIGIN_PYTHONPATH}
-    unset  $ORIGIN_PYTHONPATH
 }
 trap cleanup EXIT
 

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -77,7 +77,7 @@ dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.DBus 
 # export PYTHONPATH globally to fix Waydroid issue
 
 sudo tee -a /etc/environment.d/11-cf-waydroid.conf << EOF
-PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python3.12/site-packages/
+PYTHONPATH=$(echo /opt/3rd-party/bundles/clearfraction/usr/lib/python*/)site-packages/
 EOF
 
 echo "Setup complete. Restart for the bootloader configuration to take effect"

--- a/cf-waydroid-preinstall.sh
+++ b/cf-waydroid-preinstall.sh
@@ -74,4 +74,10 @@ done
 # Fix for dbus error (find issue here https://github.com/waydroid/waydroid/issues/854)
 dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 
+# export PYTHONPATH globally to fix Waydroid issue
+
+sudo tee -a /etc/environment.d/11-cf-waydroid.conf << EOF
+PYTHONPATH=/opt/3rd-party/bundles/clearfraction/usr/lib/python3.12/site-packages/
+EOF
+
 echo "Setup complete. Restart for the bootloader configuration to take effect"


### PR DESCRIPTION
The module `gbinder` needs to available for `python` to pick up. All the .desktop files that are generated summon waydroid and they require `gbinder` being available globally.
This can be checked by trying to `import gbinder` inside a `python terminal`(?). If it's unavailable, it breaks
```bash
i@clr~ $ python
Python 3.12.4 (main, Jul 12 2024, 09:28:05) [GCC 14.1.1 20240711 releases/gcc-14.1.0-234-g08c2abffe0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gbinder
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'gbinder'
```